### PR TITLE
chore: :label: update `onTap` type to be more explicit and robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ dependencies:
 | `borderRadius` |  `Double`  | `20` | The border radius of the button, defaults to 20 |
 | `progress` |  `bool`  | `false` | Whether the progress indicator is required or not, defaults to false |
 | `disabled` |  `bool`  | `false` | Disables the button, defaults to false |
-| `onTap` |  `Function`  |  | Button press handler, required* |
+| `onTap` |  `Function(void Function() finish)`  |  | Button tap handler with `finish` callback to reset the state of progress and animation when called, required* |
 | `child` |  `Widget`  |  | Inner content for the button, required* |
 
 ### Usage

--- a/lib/nice_buttons.dart
+++ b/lib/nice_buttons.dart
@@ -53,7 +53,7 @@ class NiceButtons extends StatefulWidget {
   final bool disabled;
 
   /// Button on press handler, required.
-  final Function onTap;
+  final Function(void Function() finish) onTap;
 
   /// Child widget that will be wrapped inside the button.
   final Widget child;


### PR DESCRIPTION
Hi @voonic 👋🏻

In this PR, I have updated the type of `onTap` callback as the following:

```Diff
-  final Function onTap;
+  final Function(void Function() finish) onTap;
```

This change makes it easier for developers to understand the type of the callback and allows static analysis to detect the absence or presence of the `finish` callback as a parameter. Previously, the analyzer was not able to do this, which resulted in errors being thrown at `runtime` instead of `compile` time.

I hope you like this and find it useful 💙

Thanks 🙏🏻